### PR TITLE
#145 Implement File Metadata Event Emission with Compression Data

### DIFF
--- a/contracts/src/lib.cairo
+++ b/contracts/src/lib.cairo
@@ -6,16 +6,34 @@ pub trait IHelloStarknet<TContractState> {
     fn increase_balance(ref self: TContractState, amount: felt252);
     /// Retrieve contract balance.
     fn get_balance(self: @TContractState) -> felt252;
+    /// Process file data and emit metadata event
+    fn process_file_metadata(ref self: TContractState, data_size: usize, file_type: felt252, original_size: usize);
 }
 
 /// Simple contract for managing balance.
 #[starknet::contract]
 mod HelloStarknet {
-    use core::starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     #[storage]
     struct Storage {
         balance: felt252,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        FileMetadataEvent: FileMetadataEvent,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct FileMetadataEvent {
+        #[key]
+        file_type: felt252,
+        size: usize,
+        original_size: usize,
+        new_size: usize,
+        compression_ratio: u64,
     }
 
     #[abi(embed_v0)]
@@ -27,6 +45,28 @@ mod HelloStarknet {
 
         fn get_balance(self: @ContractState) -> felt252 {
             self.balance.read()
+        }
+
+        fn process_file_metadata(ref self: ContractState, data_size: usize, file_type: felt252, original_size: usize) {
+            // Calculate compressed size (simplified implementation)
+            let new_size = if data_size == 0 { 0 } else { data_size / 2 };
+            
+            // Calculate compression ratio
+            let compression_ratio = if new_size == 0 {
+                0_u64
+            } else {
+                let ratio: u64 = (original_size * 100 / new_size).into();
+                ratio
+            };
+            
+            // Emit event
+            self.emit(FileMetadataEvent {
+                file_type,
+                size: data_size,
+                original_size,
+                new_size,
+                compression_ratio,
+            });
         }
     }
 }

--- a/contracts/tests/test_contract.cairo
+++ b/contracts/tests/test_contract.cairo
@@ -6,6 +6,7 @@ use contracts::IHelloStarknetSafeDispatcher;
 use contracts::IHelloStarknetSafeDispatcherTrait;
 use contracts::IHelloStarknetDispatcher;
 use contracts::IHelloStarknetDispatcherTrait;
+use core::byte_array::ByteArray;
 
 fn deploy_contract(name: ByteArray) -> ContractAddress {
     let contract = declare(name).unwrap().contract_class();
@@ -44,4 +45,21 @@ fn test_cannot_increase_balance_with_zero_value() {
             assert(*panic_data.at(0) == 'Amount cannot be 0', *panic_data.at(0));
         }
     };
+}
+
+#[test]
+fn test_process_file_metadata() {
+    let contract_address = deploy_contract("HelloStarknet");
+    let dispatcher = IHelloStarknetDispatcher { contract_address };
+    
+    // Create test data parameters
+    let data_size = 16; // Simulating size of binary data
+    let file_type = 'txt';
+    let original_size = 100; // Simulating original uncompressed size
+    
+    // Call process_file_metadata - should run without errors
+    dispatcher.process_file_metadata(data_size, file_type, original_size);
+    
+    // If we reached here without errors, the test passed
+    assert(true, 'Test passed');
 }


### PR DESCRIPTION
   This PR implements the File Metadata Event Emission feature as requested in issue #145.

   ## Changes:
   - Added `process_file_metadata` function to accept file metadata and emit events
   - Created FileMetadataEvent event structure with all required fields 
   - Implemented compression ratio calculation
   - Added test for the new functionality
   
   ## Technical considerations:
   - Used u64 instead of f64 for compression ratio as Cairo doesn't support floating point
   - Simulated compression with a 50% reduction ratio
   - Modified the interface slightly to work with Cairo's limitations
   
   Closes #145