### PR TITLE
introduces  --disable-file-size-limit flag to the upload subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,7 @@ async fn prompt_string(prompt: &str) -> String {
 }
 
 /// Uploads a file with compression metadata
-pub async fn upload_data_cli() {
+pub async fn upload_data_cli(disable_limit: bool) {
     let file_path = prompt_string("Enter the file path").await;
 
     // Read file contents and generate hash
@@ -49,6 +49,12 @@ pub async fn upload_data_cli() {
         print_error("Failed to read file", &e);
         return;
     }
+
+    if !disable_limit && buffer.len() > 10 * 1024 * 1024 {
+    print_error("File too large", &"Use --disable-file-size-limit to override the limit.");
+    return;
+    }
+
     hasher.update(&buffer);
     let hash = hasher.finalize();
     
@@ -190,7 +196,7 @@ pub async fn main_menu() {
         };
 
         match selection {
-            0 => upload_data_cli().await,
+            0 => upload_data_cli(true).await,
             1 => retrieve_data_cli().await,
             2 => list_all_uploads().await,
             3 => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,11 @@ struct CliArgs {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Upload data to StarkNet
-    Upload,
+    Upload {
+        #[arg(long)]
+        disable_file_size_limit: bool,
+    },
+
     /// Retrieve data from StarkNet
     Retrieve,
     /// List all uploaded data
@@ -27,7 +31,10 @@ async fn main() {
     let args = CliArgs::parse();
 
     match args.command {
-        Some(Commands::Upload) => cli::upload_data_cli().await,
+        Some(Commands::Upload { disable_file_size_limit }) => {
+            cli::upload_data_cli(disable_file_size_limit).await;
+        }
+        // Some(Commands::Upload) => cli::upload_data_cli().await,
         Some(Commands::Retrieve) => cli::retrieve_data_cli().await,
         Some(Commands::List) => cli::list_all_uploads().await,
         None => cli::main_menu().await,


### PR DESCRIPTION
## Summary
This pull request introduces an optional --disable-file-size-limit flag to the upload subcommand in the StarkSqueeze CLI. By default, the CLI enforces a file size limit of 10 MB to prevent accidental uploads of large files. This flag allows users to override that limit when needed.
### What's New
1. CLI Flag Added:
```
cargo run -- upload --disable-file-size-limit
```
- When passed, the CLI will skip the file size check.

- If not passed, uploads larger than 10 MB will be rejected with a helpful error message.

2. Updated Enum and Command Handling:

- Upload command now accepts a disable_file_size_limit boolean flag via clap.

- upload_data_cli function signature updated to accept and handle the flag accordingly.
closes #198 