### PR TITLE
Debug decompression failure

### DIFF
--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -424,9 +424,9 @@ pub fn reconstruct_from_minimal_mapping(
         let chunk = mapping.byte_to_chunk.get(&byte)
             .ok_or_else(|| MappingError::InvalidMapping(format!("Byte {} not found in mapping", byte)))?;
         
-        // Convert chunk bytes back to binary string
+        // Convert chunk bytes back to binary string (8-bit representation)
         for &chunk_byte in chunk {
-            binary_string.push(chunk_byte as char);
+            binary_string.push_str(&format!("{:08b}", chunk_byte));
         }
     }
     fs::write("debug_reconstructed_binary_string.txt", &binary_string).expect("Failed to write debug_reconstructed_binary_string.txt");


### PR DESCRIPTION
Fix decompression by correctly converting bytes to 8-bit binary strings to match compression.

During compression, ASCII bytes were converted to their 8-bit binary string representation. However, the `reconstruct_from_minimal_mapping` function in decompression incorrectly converted these bytes directly to characters, leading to an inconsistent binary string reconstruction and preventing proper reversal to the original file. This PR ensures the decompression process correctly formats the binary string.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-1c33317a-4abc-4ba4-8551-5b73c7ed3633) · [Cursor](https://cursor.com/background-agent?bcId=bc-1c33317a-4abc-4ba4-8551-5b73c7ed3633)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)