### PR TITLE
Debug decompression failure

### DIFF
--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -424,9 +424,9 @@ pub fn reconstruct_from_minimal_mapping(
         let chunk = mapping.byte_to_chunk.get(&byte)
             .ok_or_else(|| MappingError::InvalidMapping(format!("Byte {} not found in mapping", byte)))?;
         
-        // Convert chunk bytes back to binary string
+        // Convert chunk bytes back to binary string (8-bit representation)
         for &chunk_byte in chunk {
-            binary_string.push(chunk_byte as char);
+            binary_string.push_str(&format!("{:08b}", chunk_byte));
         }
     }
     fs::write("debug_reconstructed_binary_string.txt", &binary_string).expect("Failed to write debug_reconstructed_binary_string.txt");


### PR DESCRIPTION
Fix decompression logic for both mapping-based and CLI dictionary-based systems to ensure correct data reversal.

The `reconstruct_from_minimal_mapping` function in `src/mapping.rs` was incorrectly converting chunk bytes to characters instead of their 8-bit binary string. The `decompress_file_cli` in `src/cli.rs` was missing the binary string to ASCII byte conversion and subsequent ASCII reversal steps.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-1c33317a-4abc-4ba4-8551-5b73c7ed3633) · [Cursor](https://cursor.com/background-agent?bcId=bc-1c33317a-4abc-4ba4-8551-5b73c7ed3633)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)